### PR TITLE
Refactor API storage

### DIFF
--- a/interfaces/dispatchers.py
+++ b/interfaces/dispatchers.py
@@ -250,20 +250,22 @@ class AppEventDispatcher(object):
             UnknownApp: If the app specified is not found in all known app APIs or the app has no actions
             UnknownAppAction: If the action is not found in the give app's actions
         """
-        try:
-            available_actions = set(walkoff.config.app_apis[app]['actions'].keys())
-            if actions == 'all':
-                return available_actions
-            actions = set(convert_to_iterable(actions))
-            if actions - available_actions:
-                message = 'Unknown actions for app {0}: {1}'.format(app, list(set(actions) - set(available_actions)))
-                _logger.error(message)
-                raise UnknownAppAction(app, actions)
-            return actions
-        except KeyError:
-            message = 'Unknown app {} or app has no actions'.format(app)
+        app_apis = walkoff.config.app_apis
+        if app not in app_apis:
+            message = 'Unknown app {}'.format(app)
             _logger.exception(message)
             raise UnknownApp(app)
+
+        api = app_apis[app]
+        available_actions = set(api.actions.keys())
+        if actions == 'all':
+            return available_actions
+        actions = set(convert_to_iterable(actions))
+        if actions - available_actions:
+            message = 'Unknown actions for app {0}: {1}'.format(app, list(set(actions) - set(available_actions)))
+            _logger.error(message)
+            raise UnknownAppAction(app, actions)
+        return actions
 
     def is_registered(self, app, action, event, device, func):
         """Is a given callback registered

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -24,7 +24,7 @@ def run_tests():
     ret = True
     print('Testing Integration:')
     ret &= unittest.TextTestRunner(verbosity=1).run(test_suites.integration_suite).wasSuccessful()
-    print('Testing Workflows:')
+    print('\nTesting Workflows:')
     ret &= unittest.TextTestRunner(verbosity=1).run(test_suites.workflow_suite).wasSuccessful()
     print('\nTesting Execution:')
     ret &= unittest.TextTestRunner(verbosity=1).run(test_suites.execution_suite).wasSuccessful()

--- a/tests/test_app_api_validation.py
+++ b/tests/test_app_api_validation.py
@@ -9,6 +9,7 @@ from tests.util import initialize_test_config
 from walkoff.appgateway import get_app_action
 from walkoff.appgateway.apiutil import UnknownApp
 from walkoff.appgateway.validator import *
+from walkoff.definitions import DeviceApi
 
 
 class TestAppApiValidation(unittest.TestCase):
@@ -316,4 +317,4 @@ class TestAppApiValidation(unittest.TestCase):
                             'fields': [{'name': 'param1', 'type': 'integer', 'default': 'invalid'}]}}
         self.basicapi['devices'] = devices
         with self.assertRaises(InvalidArgument):
-            validate_devices_api(devices, '')
+            validate_devices_api({key: DeviceApi(value) for key, value in devices.items()}, '')

--- a/tests/test_app_event_dispatcher.py
+++ b/tests/test_app_event_dispatcher.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 import walkoff.config
 from interfaces import AppEventDispatcher
+from walkoff.definitions import AppApi
 from walkoff.events import WalkoffEvent, EventType
 from walkoff.appgateway.apiutil import UnknownApp, UnknownAppAction
 
@@ -12,10 +13,12 @@ def func(): pass
 class TestAppEventDispatcher(TestCase):
     @classmethod
     def setUpClass(cls):
-        walkoff.config.app_apis = {'App1': {'actions': {'action1': None,
-                                                        'action2': None,
-                                                        'action3': None}},
-                                   'App2': {}}
+        walkoff.config.app_apis = {
+            'App1': AppApi({'actions': {
+                'action1': None, 'action2': None, 'action3': None
+            }}),
+            'App2': AppApi({})
+        }
         cls.possible_events = {event for event in WalkoffEvent if event.event_type == EventType.action}
 
     @classmethod
@@ -41,7 +44,7 @@ class TestAppEventDispatcher(TestCase):
             AppEventDispatcher.validate_app_actions('Invalid', 'action1')
 
     def test_validate_app_actions_app_with_no_actions(self):
-        with self.assertRaises(UnknownApp):
+        with self.assertRaises(UnknownAppAction):
             AppEventDispatcher.validate_app_actions('App2', 'action1')
 
     def test_validate_app_actions_all_actions(self):

--- a/tests/test_device_server.py
+++ b/tests/test_device_server.py
@@ -3,6 +3,7 @@ import os
 
 import walkoff.config
 from tests.util.servertestcase import ServerTestCase
+from walkoff.definitions import AppApi
 from walkoff.executiondb.device import Device, App, DeviceField, EncryptedDeviceField
 from walkoff.server.returncodes import *
 
@@ -25,8 +26,8 @@ class TestDevicesServer(ServerTestCase):
             self.app.running_context.execution_db.session.delete(app)
         self.app.running_context.execution_db.session.commit()
         walkoff.config.app_apis = {}
-        if os.path.exists(os.path.join(walkoff.config.Config.APPS_PATH, 'testDevice.json')):
-            os.remove(os.path.join(walkoff.config.Config.APPS_PATH, 'testDevice.json'))
+        if os.path.exists(os.path.join(walkoff.config.APPS_PATH, 'testDevice.json')):
+            os.remove(os.path.join(walkoff.config.APPS_PATH, 'testDevice.json'))
 
     def test_read_all_devices_no_devices_in_db(self):
         response = self.get_with_status_check('/api/devices', headers=self.headers, status_code=SUCCESS)
@@ -87,7 +88,7 @@ class TestDevicesServer(ServerTestCase):
     def test_create_device_app_not_in_apis(self):
         fields_json = [{'name': 'test_name', 'type': 'integer', 'encrypted': False},
                        {'name': 'test2', 'type': 'string', 'encrypted': False}]
-        walkoff.config.app_apis = {self.test_app_name: {'devices': {'test_type': {'fields': fields_json}}}}
+        walkoff.config.app_apis = {self.test_app_name: AppApi({'devices': {'test_type': {'fields': fields_json}}})}
 
         device_json = {'app_name': 'Invalid', 'name': 'test', 'type': 'some_type', 'fields': []}
         self.post_with_status_check('/api/devices', headers=self.headers, data=json.dumps(device_json),
@@ -96,7 +97,7 @@ class TestDevicesServer(ServerTestCase):
     def test_create_device_device_type_does_not_exist(self):
         fields_json = [{'name': 'test_name', 'type': 'integer', 'encrypted': False},
                        {'name': 'test2', 'type': 'string', 'encrypted': False}]
-        walkoff.config.app_apis = {self.test_app_name: {'devices': {'test_type': {'fields': fields_json}}}}
+        walkoff.config.app_apis = {self.test_app_name: AppApi({'devices': {'test_type': {'fields': fields_json}}})}
 
         device_json = {'app_name': 'TestApp', 'name': 'test', 'type': 'invalid', 'fields': []}
         self.post_with_status_check('/api/devices', headers=self.headers, data=json.dumps(device_json),
@@ -105,7 +106,7 @@ class TestDevicesServer(ServerTestCase):
     def test_create_device_invalid_fields(self):
         fields_json = [{'name': 'test_name', 'type': 'integer', 'encrypted': False},
                        {'name': 'test2', 'type': 'string', 'encrypted': False}]
-        walkoff.config.app_apis = {self.test_app_name: {'devices': {'test_type': {'fields': fields_json}}}}
+        walkoff.config.app_apis = {self.test_app_name: AppApi({'devices': {'test_type': {'fields': fields_json}}})}
 
         device_json = {'app_name': 'TestApp', 'name': 'test', 'type': 'test_type',
                        'fields': [{'name': 'test_name', 'value': 'invalid'}, {'name': 'test2', 'value': 'something'}]}
@@ -115,7 +116,7 @@ class TestDevicesServer(ServerTestCase):
     def test_create_device_app_not_in_db(self):
         fields_json = [{'name': 'test_name', 'type': 'integer', 'encrypted': False},
                        {'name': 'test2', 'type': 'string', 'encrypted': False}]
-        walkoff.config.app_apis = {self.test_app_name: {'devices': {'test_type': {'fields': fields_json}}}}
+        walkoff.config.app_apis = {self.test_app_name: AppApi({'devices': {'test_type': {'fields': fields_json}}})}
 
         device_json = {'app_name': 'TestApp', 'name': 'test', 'type': 'test_type',
                        'fields': [{'name': 'test_name', 'value': 123}, {'name': 'test2', 'value': 'something'}]}
@@ -125,7 +126,7 @@ class TestDevicesServer(ServerTestCase):
     def test_create_device(self):
         fields_json = [{'name': 'test_name', 'type': 'integer', 'encrypted': False},
                        {'name': 'test2', 'type': 'string', 'encrypted': False}]
-        walkoff.config.app_apis = {self.test_app_name: {'devices': {'test_type': {'fields': fields_json}}}}
+        walkoff.config.app_apis = {self.test_app_name: AppApi({'devices': {'test_type': {'fields': fields_json}}})}
         app = App(name=self.test_app_name)
         self.app.running_context.execution_db.session.add(app)
         self.app.running_context.execution_db.session.commit()
@@ -169,7 +170,7 @@ class TestDevicesServer(ServerTestCase):
 
         fields_json = [{'name': 'test_name', 'type': 'integer', 'encrypted': False},
                        {'name': 'test2', 'type': 'string', 'encrypted': False}]
-        walkoff.config.app_apis = {self.test_app_name: {'devices': {'test_type': {'fields': fields_json}}}}
+        walkoff.config.app_apis = {self.test_app_name: AppApi({'devices': {'test_type': {'fields': fields_json}}})}
 
         data = {'id': device1.id, 'name': 'renamed', 'app_name': self.test_app_name, 'type': 'Invalid'}
         self.put_with_status_check('/api/devices', headers=self.headers, data=json.dumps(data),
@@ -184,7 +185,7 @@ class TestDevicesServer(ServerTestCase):
 
         fields_json = [{'name': 'test_name', 'type': 'integer', 'encrypted': False},
                        {'name': 'test2', 'type': 'string', 'encrypted': False}]
-        walkoff.config.app_apis = {self.test_app_name: {'devices': {'test_type': {'fields': fields_json}}}}
+        walkoff.config.app_apis = {self.test_app_name: AppApi({'devices': {'test_type': {'fields': fields_json}}})}
 
         fields_json = [{'name': 'test_name', 'value': 'invalid'}, {'name': 'test2', 'value': 'something'}]
 
@@ -203,7 +204,7 @@ class TestDevicesServer(ServerTestCase):
 
         fields_json = [{'name': 'test_name', 'type': 'integer', 'encrypted': False},
                        {'name': 'test2', 'type': 'string', 'encrypted': False}]
-        walkoff.config.app_apis = {self.test_app_name: {'devices': {'test_type': {'fields': fields_json}}}}
+        walkoff.config.app_apis = {self.test_app_name: AppApi({'devices': {'test_type': {'fields': fields_json}}})}
 
         fields_json = [{'name': 'test_name', 'value': 123}, {'name': 'test2', 'value': 'something'}]
 
@@ -222,7 +223,7 @@ class TestDevicesServer(ServerTestCase):
         self.put_patch_update('patch')
 
     def test_export_apps_devices(self):
-        walkoff.config.load_app_apis(apps_path=walkoff.config.Config.APPS_PATH)
+        walkoff.config.load_app_apis(apps_path=walkoff.config.APPS_PATH)
 
         fields = [{"name": "Text field", "value": "texts"}, {"name": "Encrypted field", "value": "encrypted"},
                   {"name": "Number field", "value": 5}, {"name": "Enum field", "value": "val 1"},
@@ -244,7 +245,7 @@ class TestDevicesServer(ServerTestCase):
                 {k.encode("utf-8"): str(v).encode("utf-8") for k, v in field.items()})))
 
     def test_import_apps_devices(self):
-        walkoff.config.load_app_apis(apps_path=walkoff.config.Config.APPS_PATH)
+        walkoff.config.load_app_apis(apps_path=walkoff.config.APPS_PATH)
 
         fields = [{"name": "Text field", "value": "texts"}, {"name": "Number field", "value": 5},
                   {"name": "Enum field", "value": "val 1"}, {"name": "Boolean field", "value": True}]
@@ -258,7 +259,7 @@ class TestDevicesServer(ServerTestCase):
         for field in device['fields']:
             field.pop('id', None)
 
-        path = os.path.join(walkoff.config.Config.APPS_PATH, 'testDevice.json')
+        path = os.path.join(walkoff.config.APPS_PATH, 'testDevice.json')
         with open(path, 'w') as f:
             f.write(json.dumps(device, indent=4, sort_keys=True))
 

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -4,6 +4,7 @@ import unittest
 from walkoff.appgateway.validator import validate_parameter, validate_parameters, convert_json
 from walkoff.executiondb.argument import Argument
 from walkoff.appgateway.apiutil import InvalidArgument
+from walkoff.definitions import ParameterApi, ParameterSchema
 
 
 class TestInputValidation(unittest.TestCase):
@@ -12,49 +13,49 @@ class TestInputValidation(unittest.TestCase):
         cls.message = 'app1 action1'
 
     def test_validate_parameter_primitive_no_formats_not_required_valid_string(self):
-        parameter_api = {'name': 'name1', 'type': 'string'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'string'})
         value = 'test string'
         self.assertEqual(validate_parameter(value, parameter_api, self.message), value)
         value = ''
         self.assertEqual(validate_parameter(value, parameter_api, self.message), value)
 
     def test_validate_parameter_primitive_no_formats_not_required_valid_number(self):
-        parameter_api = {'name': 'name1', 'type': 'number'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'number'})
         value = '3.27'
         self.assertEqual(validate_parameter(value, parameter_api, self.message), 3.27)
 
     def test_validate_parameter_primitive_no_formats_not_required_valid_negative_number(self):
-        parameter_api = {'name': 'name1', 'type': 'number'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'number'})
         value = '-3.27'
         self.assertEqual(validate_parameter(value, parameter_api, self.message), -3.27)
 
     def test_validate_parameter_primitive_no_formats_not_required_valid_int(self):
-        parameter_api = {'name': 'name1', 'type': 'integer'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'integer'})
         value = '3'
         self.assertEqual(validate_parameter(value, parameter_api, self.message), 3)
 
     def test_validate_parameter_primitive_no_formats_not_required_valid_int_from_float(self):
-        parameter_api = {'name': 'name1', 'type': 'integer'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'integer'})
         value = 3.27
         self.assertEqual(validate_parameter(value, parameter_api, self.message), 3)
 
     def test_validate_parameter_primitive_no_formats_not_required_valid_negative_int(self):
-        parameter_api = {'name': 'name1', 'type': 'integer'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'integer'})
         value = '-3'
         self.assertEqual(validate_parameter(value, parameter_api, self.message), -3)
 
     def test_validate_parameter_primitive_user(self):
-        parameter_api = {'name': 'name1', 'type': 'user'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'user'})
         value = '3'
         self.assertEqual(validate_parameter(value, parameter_api, self.message), 3)
 
     def test_validate_parameter_primitive_role(self):
-        parameter_api = {'name': 'name1', 'type': 'role'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'role'})
         value = '42'
         self.assertEqual(validate_parameter(value, parameter_api, self.message), 42)
 
     def test_validate_parameter_primitive_no_formats_not_required_valid_bool(self):
-        parameter_api = {'name': 'name1', 'type': 'boolean'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'boolean'})
         true_values = ['true', 'True', 'TRUE', 'TrUe']
         false_values = ['false', 'False', 'FALSE', 'FaLSe']
         for true_value in true_values:
@@ -63,108 +64,108 @@ class TestInputValidation(unittest.TestCase):
             self.assertEqual(validate_parameter(false_value, parameter_api, self.message), False)
 
     def test_validate_parameter_primitive_no_formats_required_string(self):
-        parameter_api = {'name': 'name1', 'type': 'string', 'required': True}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'string', 'required': True})
         value = 'test string'
         self.assertEqual(validate_parameter(value, parameter_api, self.message), value)
         value = ''
         self.assertEqual(validate_parameter(value, parameter_api, self.message), value)
 
     def test_validate_parameter_primitive_no_formats_required_none(self):
-        parameter_apis = [{'name': 'name1', 'type': 'string', 'required': True},
-                          {'name': 'name1', 'type': 'number', 'required': True},
-                          {'name': 'name1', 'type': 'integer', 'required': True},
-                          {'name': 'name1', 'type': 'boolean', 'required': True}]
+        parameter_apis = [ParameterApi({'name': 'name1', 'type': 'string', 'required': True}),
+                          ParameterApi({'name': 'name1', 'type': 'number', 'required': True}),
+                          ParameterApi({'name': 'name1', 'type': 'integer', 'required': True}),
+                          ParameterApi({'name': 'name1', 'type': 'boolean', 'required': True})]
         for parameter_api in parameter_apis:
             with self.assertRaises(InvalidArgument):
                 validate_parameter(None, parameter_api, self.message)
 
     def test_validate_parameter_primitive_not_required_none(self):
-        parameter_apis = [{'name': 'name1', 'type': 'string', 'required': False},
-                          {'name': 'name1', 'type': 'number', 'required': False},
-                          {'name': 'name1', 'type': 'integer'},
-                          {'name': 'name1', 'type': 'boolean'}]
+        parameter_apis = [ParameterApi({'name': 'name1', 'type': 'string', 'required': False}),
+                          ParameterApi({'name': 'name1', 'type': 'number', 'required': False}),
+                          ParameterApi({'name': 'name1', 'type': 'integer'}),
+                          ParameterApi({'name': 'name1', 'type': 'boolean'})]
         for parameter_api in parameter_apis:
             self.assertIsNone(validate_parameter(None, parameter_api, self.message))
 
     def test_validate_parameter_primitive_no_formats_invalid_number(self):
-        parameter_api = {'name': 'name1', 'type': 'number'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'number'})
         value = 'abc'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_primitive_no_formats_invalid_integer_cause_string(self):
-        parameter_api = {'name': 'name1', 'type': 'integer'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'integer'})
         value = 'abc'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_primitive_no_formats_invalid_user_cause_string(self):
-        parameter_api = {'name': 'name1', 'type': 'user'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'user'})
         value = 'abc'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_primitive_no_formats_invalid_role_cause_string(self):
-        parameter_api = {'name': 'name1', 'type': 'role'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'role'})
         value = 'admin'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_primitive_no_formats_invalid_user_cause_0(self):
-        parameter_api = {'name': 'name1', 'type': 'user'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'user'})
         value = '0'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_primitive_no_formats_invalid_role_cause_0(self):
-        parameter_api = {'name': 'name1', 'type': 'role'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'role'})
         value = '0'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_primitive_no_formats_invalid_integer_cause_float_string(self):
-        parameter_api = {'name': 'name1', 'type': 'integer'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'integer'})
         value = '3.27'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_primitive_no_formats_invalid_boolean(self):
-        parameter_api = {'name': 'name1', 'type': 'boolean'}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'boolean'})
         value = 'abc'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_primitive_string_format_valid(self):
-        parameter_api = {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25}
+        parameter_api = ParameterSchema({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25})
         value = 'test string'
         self.assertEqual(validate_parameter(value, parameter_api, self.message), value)
 
     def test_validate_parameter_primitive_string_format_enum_valid(self):
-        parameter_api = {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}
+        parameter_api = ParameterSchema({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']})
         value = 'test'
         self.assertEqual(validate_parameter(value, parameter_api, self.message), value)
 
     def test_validate_parameter_primitive_string_format_invalid(self):
-        parameter_api = {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 3}
+        parameter_api = ParameterSchema({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 3})
         value = 'test string'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_primitive_string_format_enum_invalid(self):
-        parameter_api = {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}
+        parameter_api = ParameterSchema({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']})
         value = 'test2'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_object(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'object',
                        'required': ['a', 'b'],
                        'properties':
                            {'a': {'type': 'number'},
                             'b': {'type': 'string'},
-                            'c': {'type': 'boolean'}}}}
+                            'c': {'type': 'boolean'}}}})
         value = {'a': 435.6, 'b': 'aaaa', 'c': True}
         validate_parameter(value, parameter_api, self.message)
 
@@ -181,53 +182,53 @@ class TestInputValidation(unittest.TestCase):
         validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_object_invalid(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'object',
                        'required': ['a', 'b'],
                        'properties':
                            {'a': {'type': 'number'},
                             'b': {'type': 'string'},
-                            'c': {'type': 'boolean'}}}}
+                            'c': {'type': 'boolean'}}}})
         value = {'a': 435.6, 'invalid': 'aaaa', 'c': True}
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_object_array(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'array',
                        'items': {'type': 'object',
                                  'properties': {'A': {'type': 'string'},
                                                 'B': {'type': 'integer'}}}
-                       }}
+                       }})
         value = [{'A': 'string in', 'B': '33'}, {'A': 'string2', 'B': '7'}]
         validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_object_array_invalid(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'array',
                        'items': {'type': 'object',
                                  'properties': {'A': {'type': 'string'},
 
                                                 'B': {'type': 'integer'}}}
-                       }}
+                       }})
         value = [{'A': 'string in', 'B': '33'}, {'A': 'string2', 'B': 'invalid'}]
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameter_invalid_data_type(self):
-        parameter_api = {'name': 'name1', 'type': 'invalid', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}
+        parameter_api = ParameterApi({'name': 'name1', 'type': 'invalid', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']})
         value = 'test2'
         with self.assertRaises(InvalidArgument):
             validate_parameter(value, parameter_api, self.message)
 
     def test_validate_parameters_all_valid_no_defaults(self):
         parameter_apis = [
-            {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']},
-            {'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25},
-            {'name': 'name3', 'type': 'number', 'minimum': -10.5, 'maximum': 30.725}]
+            ParameterApi({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}),
+            ParameterApi({'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25}),
+            ParameterApi({'name': 'name3', 'type': 'number', 'minimum': -10.5, 'maximum': 30.725})]
         arguments = [Argument('name1', value='test'),
                      Argument('name2', value='5'),
                      Argument('name3', value='10.2378')]
@@ -236,9 +237,9 @@ class TestInputValidation(unittest.TestCase):
 
     def test_validate_parameters_invalid_no_defaults(self):
         parameter_apis = [
-            {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']},
-            {'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25},
-            {'name': 'name3', 'type': 'number', 'minimum': -10.5, 'maximum': 30.725}]
+            ParameterApi({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}),
+            ParameterApi({'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25}),
+            ParameterApi({'name': 'name3', 'type': 'number', 'minimum': -10.5, 'maximum': 30.725})]
         arguments = [Argument('name1', value='test'),
                      Argument('name2', value='5'),
                      Argument('name3', value='-11.2378')]
@@ -247,9 +248,9 @@ class TestInputValidation(unittest.TestCase):
 
     def test_validate_parameters_missing_with_valid_default(self):
         parameter_apis = [
-            {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']},
-            {'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25},
-            {'name': 'name3', 'type': 'number', 'minimum': -10.5, 'maximum': 30.725, 'default': 10.25}]
+            ParameterApi({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}),
+            ParameterApi({'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25}),
+            ParameterApi({'name': 'name3', 'type': 'number', 'minimum': -10.5, 'maximum': 30.725, 'default': 10.25})]
         arguments = [Argument('name1', value='test'),
                      Argument('name2', value='5')]
         expected = {'name1': 'test', 'name2': 5, 'name3': 10.25}
@@ -257,9 +258,9 @@ class TestInputValidation(unittest.TestCase):
 
     def test_validate_parameters_missing_with_invalid_default(self):
         parameter_apis = [
-            {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']},
-            {'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25},
-            {'name': 'name3', 'type': 'number', 'minimum': -10.5, 'maximum': 30.725, 'default': 'abc'}]
+            ParameterApi({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}),
+            ParameterApi({'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25}),
+            ParameterApi({'name': 'name3', 'type': 'number', 'minimum': -10.5, 'maximum': 30.725, 'default': 'abc'})]
         arguments = [Argument('name1', value='test'),
                      Argument('name2', value='5')]
         expected = {'name1': 'test', 'name2': 5, 'name3': 'abc'}
@@ -267,9 +268,9 @@ class TestInputValidation(unittest.TestCase):
 
     def test_validate_parameters_missing_without_default(self):
         parameter_apis = [
-            {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']},
-            {'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25},
-            {'name': 'name3', 'type': 'number', 'minimum': -10.5, 'maximum': 30.725}]
+            ParameterApi({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}),
+            ParameterApi({'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25}),
+            ParameterApi({'name': 'name3', 'type': 'number', 'minimum': -10.5, 'maximum': 30.725})]
         arguments = [Argument('name1', value='test'),
                      Argument('name2', value='5')]
         expected = {'name1': 'test', 'name2': 5, 'name3': None}
@@ -277,9 +278,9 @@ class TestInputValidation(unittest.TestCase):
 
     def test_validate_parameters_missing_required_without_default(self):
         parameter_apis = [
-            {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']},
-            {'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25},
-            {'name': 'name3', 'type': 'number', 'required': True, 'minimum': -10.5, 'maximum': 30.725}]
+            ParameterApi({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}),
+            ParameterApi({'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25}),
+            ParameterApi({'name': 'name3', 'type': 'number', 'required': True, 'minimum': -10.5, 'maximum': 30.725})]
         arguments = [Argument('name1', value='test'),
                      Argument('name2', value='5')]
         with self.assertRaises(InvalidArgument):
@@ -287,8 +288,8 @@ class TestInputValidation(unittest.TestCase):
 
     def test_validate_parameters_too_many_inputs(self):
         parameter_apis = [
-            {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']},
-            {'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25}]
+            ParameterApi({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}),
+            ParameterApi({'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25})]
         arguments = [Argument('name1', value='test'),
                      Argument('name2', value='5'),
                      Argument('name3', value='-11.2378')]
@@ -297,9 +298,9 @@ class TestInputValidation(unittest.TestCase):
 
     def test_validate_parameters_skip_action_references(self):
         parameter_apis = [
-            {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']},
-            {'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25},
-            {'name': 'name3', 'type': 'number', 'required': True, 'minimum': -10.5, 'maximum': 30.725}]
+            ParameterApi({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}),
+            ParameterApi({'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25}),
+            ParameterApi({'name': 'name3', 'type': 'number', 'required': True, 'minimum': -10.5, 'maximum': 30.725})]
         arguments = [Argument('name1', value='test'),
                      Argument('name2', value='5'),
                      Argument('name3', reference='action1')]
@@ -308,9 +309,9 @@ class TestInputValidation(unittest.TestCase):
 
     def test_validate_parameters_skip_action_references_inputs_non_string(self):
         parameter_apis = [
-            {'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']},
-            {'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25},
-            {'name': 'name3', 'type': 'number', 'required': True, 'minimum': -10.5, 'maximum': 30.725}]
+            ParameterApi({'name': 'name1', 'type': 'string', 'minLength': 1, 'maxLength': 25, 'enum': ['test', 'test3']}),
+            ParameterApi({'name': 'name2', 'type': 'integer', 'minimum': -3, 'maximum': 25}),
+            ParameterApi({'name': 'name3', 'type': 'number', 'required': True, 'minimum': -10.5, 'maximum': 30.725})]
         arguments = [Argument('name1', value='test'),
                      Argument('name2', value=5),
                      Argument('name3', reference='action1')]
@@ -318,33 +319,33 @@ class TestInputValidation(unittest.TestCase):
         self.assertDictEqual(validate_parameters(parameter_apis, arguments, self.message), expected)
 
     def test_convert_json(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'object',
                        'required': ['a', 'b'],
                        'properties':
                            {'a': {'type': 'number'},
                             'b': {'type': 'string'},
-                            'c': {'type': 'boolean'}}}}
+                            'c': {'type': 'boolean'}}}})
         value = {'a': '435.6', 'b': 'aaaa', 'c': 'true'}
         converted = convert_json(parameter_api, value, self.message)
         self.assertDictEqual(converted, {'a': 435.6, 'b': 'aaaa', 'c': True})
 
     def test_convert_json_invalid(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'object',
                        'required': ['a', 'b'],
                        'properties':
                            {'a': {'type': 'number'},
                             'b': {'type': 'string'},
-                            'c': {'type': 'boolean'}}}}
+                            'c': {'type': 'boolean'}}}})
         value = {'a': '435.6', 'b': 'aaaa', 'c': 'invalid'}
         with self.assertRaises(InvalidArgument):
             convert_json(parameter_api, value, self.message)
 
     def test_convert_json_nested(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'object',
                        'required': ['a', 'b'],
@@ -353,13 +354,13 @@ class TestInputValidation(unittest.TestCase):
                             'b': {'type': 'string'},
                             'c': {'type': 'object',
                                   'properties': {'A': {'type': 'string'},
-                                                 'B': {'type': 'integer'}}}}}}
+                                                 'B': {'type': 'integer'}}}}}})
         value = {'a': '435.6', 'b': 'aaaa', 'c': {'A': 'string in', 'B': '3'}}
         converted = convert_json(parameter_api, value, self.message)
         self.assertDictEqual(converted, {'a': 435.6, 'b': 'aaaa', 'c': {'A': 'string in', 'B': 3}})
 
     def test_convert_json_nested_invalid(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'object',
                        'required': ['a', 'b'],
@@ -368,38 +369,38 @@ class TestInputValidation(unittest.TestCase):
                             'b': {'type': 'string'},
                             'c': {'type': 'object',
                                   'properties': {'A': {'type': 'string'},
-                                                 'B': {'type': 'integer'}}}}}}
+                                                 'B': {'type': 'integer'}}}}}})
         value = {'a': '435.6', 'b': 'aaaa', 'c': {'A': 'string in', 'B': 'invalid'}}
         with self.assertRaises(InvalidArgument):
             convert_json(parameter_api, value, self.message)
 
     def test_convert_primitive_array(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'array',
-                       'items': {'type': 'number'}}}
+                       'items': {'type': 'number'}}})
         value = ['1.3', '3.4', '555.1', '-132.2']
         converted = convert_json(parameter_api, value, self.message)
         self.assertListEqual(converted, [1.3, 3.4, 555.1, -132.2])
 
     def test_convert_primitive_array_invalid(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'array',
-                       'items': {'type': 'number'}}}
+                       'items': {'type': 'number'}}})
         value = ['1.3', '3.4', '555.1', 'invalid']
         with self.assertRaises(InvalidArgument):
             convert_json(parameter_api, value, self.message)
 
     def test_convert_object_array(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'array',
                        'items': {
                            'type': 'object',
                            'properties': {'A': {'type': 'string'},
                                           'B': {'type': 'integer'}}}
-                       }}
+                       }})
         value = [{'A': 'string in', 'B': '33'}, {'A': 'string2', 'B': '7'}]
         expected = [{'A': 'string in', 'B': 33}, {'A': 'string2', 'B': 7}]
         converted = convert_json(parameter_api, value, self.message)
@@ -408,22 +409,22 @@ class TestInputValidation(unittest.TestCase):
             self.assertDictEqual(converted[i], expected[i])
 
     def test_convert_object_array_invalid(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
             'schema': {'type': 'array',
                        'items': {
                            'type': 'object',
                            'properties': {'A': {'type': 'string'},
                                           'B': {'type': 'integer'}}}
-                       }}
+                       }})
         value = [{'A': 'string in', 'B': '33'}, {'A': 'string2', 'B': 'invalid'}]
         with self.assertRaises(InvalidArgument):
             convert_json(parameter_api, value, self.message)
 
     def test_convert_object_array_unspecified_type(self):
-        parameter_api = {
+        parameter_api = ParameterApi({
             'name': 'name1',
-            'schema': {'type': 'array'}}
+            'schema': {'type': 'array'}})
         value = ['@action1', 2, {'a': 'v', 'b': 6}]
         expected = ['@action1', 2, {'a': 'v', 'b': 6}]
         converted = convert_json(parameter_api, value, self.message)

--- a/tests/test_interface_event_dispatcher.py
+++ b/tests/test_interface_event_dispatcher.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 import walkoff.config
 import walkoff.executiondb.schemas
+from walkoff.definitions import AppApi
 from interfaces import InterfaceEventDispatcher, dispatcher
 from interfaces.exceptions import UnknownEvent
 from tests.util import execution_db_help, initialize_test_config
@@ -36,10 +37,12 @@ class TestInterfaceEventDispatcher(TestCase):
     def setUpClass(cls):
         initialize_test_config()
         execution_db_help.setup_dbs()
-        walkoff.config.app_apis = {'App1': {'actions': {'action1': None,
-                                                        'action2': None,
-                                                        'action3': None}},
-                                   'App2': {}}
+        walkoff.config.app_apis = {
+            'App1': AppApi({'actions': {
+                'action1': None, 'action2': None, 'action3': None
+             }}),
+             'App2': AppApi({})
+        }
         cls.action_events = {event for event in WalkoffEvent if
                              event.event_type == EventType.action and event != WalkoffEvent.SendMessage}
 

--- a/walkoff/appgateway/apiutil.py
+++ b/walkoff/appgateway/apiutil.py
@@ -18,9 +18,9 @@ def get_app_action_api(app, action):
         raise UnknownApp(app)
     else:
         try:
-            action_api = app_api['actions'][action]
-            run = action_api['run']
-            return run, action_api.get('parameters', [])
+            action_api = app_api.actions[action]
+            run = action_api.run
+            return run, action_api.parameters
         except KeyError:
             raise UnknownAppAction(app, action)
 
@@ -42,11 +42,8 @@ def get_app_action_default_return(app, action):
         raise UnknownApp(app)
     else:
         try:
-            action_api = app_api['actions'][action]
-            if 'default_return' in action_api:
-                return action_api['default_return']
-            else:
-                return 'Success'
+            action_api = app_api.actions[action]
+            return action_api.default_return
         except KeyError:
             raise UnknownAppAction(app, action)
 
@@ -69,11 +66,8 @@ def get_app_action_return_is_failure(app, action, status):
         raise UnknownApp(app)
     else:
         try:
-            action_api = app_api['actions'][action]
-            if 'failure' in action_api['returns'][status]:
-                return True if action_api['returns'][status]['failure'] is True else False
-            else:
-                return False
+            action_api = app_api.actions[action]
+            return action_api.returns[status].failure
         except KeyError:
             raise UnknownAppAction(app, action)
 
@@ -85,7 +79,7 @@ def get_app_device_api(app, device_type):
         raise UnknownApp(app)
     else:
         try:
-            return app_api['devices'][device_type]
+            return app_api.devices[device_type]
         except KeyError:
             raise UnknownDevice(app, device_type)
 
@@ -93,7 +87,7 @@ def get_app_device_api(app, device_type):
 def split_api_params(api, data_param_name):
     args = []
     for api_param in api:
-        if api_param['name'] != data_param_name:
+        if api_param.name != data_param_name:
             args.append(api_param)
     return args
 
@@ -105,9 +99,9 @@ def get_condition_api(app, condition):
         raise UnknownApp(app)
     else:
         try:
-            condition_api = app_api['conditions'][condition]
-            run = condition_api['run']
-            return condition_api['data_in'], run, condition_api.get('parameters', [])
+            condition_api = app_api.conditions[condition]
+            run = condition_api.run
+            return condition_api.data_in, run, condition_api.parameters
         except KeyError:
             raise UnknownCondition(app, condition)
 
@@ -119,9 +113,9 @@ def get_transform_api(app, transform):
         raise UnknownApp(app)
     else:
         try:
-            transform_api = app_api['transforms'][transform]
-            run = transform_api['run']
-            return transform_api['data_in'], run, transform_api.get('parameters', [])
+            transform_api = app_api.transforms[transform]
+            run = transform_api.run
+            return transform_api.data_in, run, transform_api.parameters
         except KeyError:
             raise UnknownTransform(app, transform)
 

--- a/walkoff/config.py
+++ b/walkoff/config.py
@@ -7,6 +7,7 @@ from os.path import isfile, join, abspath
 
 import yaml
 
+from walkoff.definitions import AppApi
 from walkoff.helpers import format_db_path
 
 logger = logging.getLogger(__name__)
@@ -36,9 +37,10 @@ def load_app_apis(apps_path=None):
             try:
                 url = join(apps_path, app, 'api.yaml')
                 with open(url) as function_file:
-                    api = yaml.load(function_file.read())
+                    api_raw = yaml.load(function_file.read())
                     from walkoff.appgateway.validator import validate_app_spec
-                    validate_app_spec(api, app, Config.WALKOFF_SCHEMA_PATH)
+                    validate_app_spec(api_raw, app, Config.WALKOFF_SCHEMA_PATH)
+                    api = AppApi(api_raw)
                     app_apis[app] = api
             except Exception as e:
                 logger.error(

--- a/walkoff/definitions.py
+++ b/walkoff/definitions.py
@@ -1,0 +1,138 @@
+def wrap(cls, value):
+    return cls(value) if value is not None else None
+
+class ApiData:
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def set_primitives(self, yaml, keys):
+        for key in keys:
+            if key in yaml:
+                setattr(self, key, yaml[key])
+
+    def set_wrappers(self, yaml, mapping):
+        for key, value in mapping.items():
+            if key in yaml:
+                setattr(self, key, value(yaml[key]))
+
+    def set_wrappers_array(self, yaml, mapping):
+        for key, value in mapping.items():
+            if key in yaml:
+                setattr(self, key, [value(x) for x in yaml[key]])
+            else:
+                setattr(self, key, [])
+
+    def set_wrappers_dict(self, yaml, mapping):
+        for key, value in mapping.items():
+            if key in yaml:
+                setattr(self, key, {key2: wrap(value, value2) for key2, value2 in yaml[key].items()})
+            else:
+                setattr(self, key, {})
+
+    def set_defaults(self, mapping):
+        for key, value in mapping.items():
+            if not hasattr(self, key):
+                setattr(self, key, value)
+
+class AppApi(ApiData):
+
+    def __init__(self, yaml):
+        self.set_wrappers(yaml, {'info': ApiInfo})
+        self.set_wrappers_array(yaml, {'tags': ApiTag, 'external_docs': ExternalDoc})
+        self.set_wrappers_dict(yaml, {'actions': ActionApi, 'conditions': ConditionApi, 'transforms': TransformApi,
+                               'devices': DeviceApi})
+
+class ApiInfo(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['title', 'version', 'description', 'terms_of_service'])
+        self.set_wrappers(yaml, {'contact': ApiContact, 'license': ApiLicense})
+
+class ApiContact(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['name', 'url', 'email'])
+
+class ApiLicense(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['name', 'url'])
+
+class ActionApi(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['name', 'run', 'default_return', 'deprecated', 'tags', 'summary', 'description'])
+        self.set_wrappers_array(yaml, {'parameters': ParameterApi, 'external_docs': ExternalDoc})
+        self.set_wrappers_dict(yaml, {'returns': ReturnApi})
+
+        self.set_defaults({'default_return': 'Success', 'deprecated': False, 'tags': []})
+
+class ConditionApi(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['name', 'run', 'data_in', 'deprecated', 'tags', 'summary', 'description'])
+        self.set_wrappers_array(yaml, {'parameters': ParameterApi, 'external_docs': ExternalDoc})
+        self.set_wrappers_dict(yaml, {'returns': ReturnApi})
+
+        self.set_defaults({'deprecated': False, 'tags': []})
+
+class TransformApi(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['name', 'run', 'data_in', 'deprecated', 'tags', 'summary', 'description'])
+        self.set_wrappers_array(yaml, {'parameters': ParameterApi, 'external_docs': ExternalDoc})
+        self.set_wrappers_dict(yaml, {'returns': ReturnApi})
+
+        self.set_defaults({'deprecated': False, 'tags': []})
+
+class DeviceApi(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['name', 'description'])
+        self.set_wrappers_array(yaml, {'fields': DeviceFieldApi})
+
+class DeviceFieldApi(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['name', 'description', 'encrypted', 'placeholder', 'required'])
+        self.set_primitives(yaml, ['type', 'default', 'minLength'])  # not in spec
+        self.set_wrappers(yaml, {'schema': ParameterSchema})
+
+        self.set_defaults({'encrypted': False, 'required': False})
+
+class ParameterApi(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['name', 'example', 'description', 'placeholder', 'required'])
+        self.set_primitives(yaml, ['type', 'default', 'minimum'])  # not in spec
+        self.set_wrappers(yaml, {'schema': ParameterSchema})
+
+        self.set_defaults({'required': False})
+
+class ReturnApi(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['status', 'description', 'failure', 'examples'])
+        self.set_wrappers(yaml, {'schema': ParameterSchema})
+
+        self.set_defaults({'failure': False})
+
+class ExternalDoc(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['description', 'url'])
+
+class ApiTag(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['name', 'description'])
+        self.set_wrappers_array(yaml, {'external_docs': ExternalDoc})
+
+class ParameterSchema(ApiData):
+
+    def __init__(self, yaml):
+        self.set_primitives(yaml, ['type', 'format', 'multipleOf', 'maximum', 'exclusiveMaximum', 'minimum',
+                            'exclusiveMinimum', 'maxLength', 'minLength', 'pattern', 'maxItems', 'minItems',
+                            'uniqueItems', 'enum'])
+        self.set_primitives(yaml, ['required', 'properties', 'items'])  # not in spec

--- a/walkoff/server/app.py
+++ b/walkoff/server/app.py
@@ -1,6 +1,8 @@
 import logging
+from uuid import UUID
 
 import connexion
+from connexion.apps.flask_app import FlaskJSONEncoder
 from flask import Blueprint
 from jinja2 import FileSystemLoader
 
@@ -13,6 +15,13 @@ from walkoff.server.blueprints import custominterface, workflowresults, notifica
 import walkoff.server.workflowresults
 
 logger = logging.getLogger(__name__)
+
+
+class CustomJSONEncoder(FlaskJSONEncoder):
+    def default(self, data):
+        if isinstance(data, UUID):
+            return str(data)
+        return data.__dict__
 
 
 def register_blueprints(flaskapp):
@@ -65,6 +74,7 @@ def __register_all_app_blueprints(flaskapp):
 def create_app(app_config):
     connexion_app = connexion.App(__name__, specification_dir='../api/')
     _app = connexion_app.app
+    _app.json_encoder = CustomJSONEncoder
     _app.jinja_loader = FileSystemLoader(['walkoff/templates'])
     _app.config.from_object(app_config)
 

--- a/walkoff/server/endpoints/appapi.py
+++ b/walkoff/server/endpoints/appapi.py
@@ -5,6 +5,7 @@ from flask_jwt_extended import jwt_required
 import walkoff.config
 from walkoff import helpers
 from walkoff.appgateway import is_app_action_bound
+from walkoff.definitions import ReturnApi
 from walkoff.security import permissions_accepted_for_resources, ResourcePermissions
 from walkoff.server.problem import Problem
 from walkoff.server.returncodes import *
@@ -21,43 +22,41 @@ def read_all_apps():
 
 
 def extract_schema(api, unformatted_fields=('name', 'example', 'placeholder', 'description', 'required')):
+    api = api.__dict__
     ret = {}
     schema = {}
     for key, value in api.items():
-        if key not in unformatted_fields:
-            schema[key] = value
-        else:
+        if key in unformatted_fields:
             ret[key] = value
+        else:
+            schema[key] = value
     ret['schema'] = schema
-    if 'schema' in ret['schema']:  # flatten the nested schema, happens when parameter is an object
-        ret['schema'].update({key: value for key, value in ret['schema'].pop('schema').items()})
+    while 'schema' in ret['schema']:  # flatten the nested schema, happens when parameter is an object
+        ret['schema'].update(ret['schema'].pop('schema').__dict__)
     return ret
 
 
 def format_returns(api, with_event=False):
     ret_returns = []
     for return_name, return_schema in api.items():
-        return_schema.update({'status': return_name})
+        return_schema.status = return_name
         ret_returns.append(return_schema)
     ret_returns.extend(
-        [{'status': 'UnhandledException', 'failure': True, 'description': 'Exception occurred in action'},
-         {'status': 'InvalidInput', 'failure': True, 'description': 'Input into the action was invalid'}])
+        [ReturnApi({'status': 'UnhandledException', 'failure': True, 'description': 'Exception occurred in action'}),
+        ReturnApi({'status': 'InvalidInput', 'failure': True, 'description': 'Input into the action was invalid'})])
     if with_event:
-        ret_returns.append(
-            {'status': 'EventTimedOut', 'failure': True, 'description': 'Action timed out out waiting for event'})
+        ret_returns.append(ReturnApi(
+            {'status': 'EventTimedOut', 'failure': True, 'description': 'Action timed out out waiting for event'}))
     return ret_returns
 
 
 def format_app_action_api(api, app_name, action_type):
     ret = deepcopy(api)
-    if 'returns' in api:
-        ret['returns'] = format_returns(ret['returns'], 'event' in api)
-    if action_type in ('conditions', 'transforms') or not is_app_action_bound(app_name, api['run']):
+    ret.returns = format_returns(ret.returns)  #, hasattr(api, 'event')
+    ret.parameters = [extract_schema(param_api) for param_api in ret.parameters]
+    ret = ret.__dict__
+    if action_type in ('conditions', 'transforms') or not is_app_action_bound(app_name, api.run):
         ret['global'] = True
-    if 'parameters' in api:
-        ret['parameters'] = [extract_schema(param_api) for param_api in ret['parameters']]
-    else:
-        ret['parameters'] = []
     return ret
 
 
@@ -73,11 +72,11 @@ def format_all_app_actions_api(api, app_name, action_type):
 def format_device_api_full(api, device_name):
     device_api = {'name': device_name}
     unformatted_fields = ('name', 'description', 'encrypted', 'placeholder', 'required')
-    if 'description' in api:
-        device_api['description'] = api['description']
+    if hasattr(api, 'description'):
+        device_api['description'] = api.description
     device_api['fields'] = [extract_schema(device_field,
                                            unformatted_fields=unformatted_fields)
-                            for device_field in api['fields']]
+                            for device_field in api.fields]
 
     return device_api
 
@@ -85,21 +84,15 @@ def format_device_api_full(api, device_name):
 def format_full_app_api(api, app_name):
     ret = {'name': app_name}
     for unformatted_field in ('info', 'tags', 'external_docs'):
-        if unformatted_field in api:
-            ret[unformatted_field] = api[unformatted_field]
+        if hasattr(api, unformatted_field):
+            ret[unformatted_field] = getattr(api, unformatted_field)
         else:
             ret[unformatted_field] = [] if unformatted_field in ('tags', 'external_docs') else {}
     for formatted_action_field in ('actions', 'conditions', 'transforms'):
-        if formatted_action_field in api:
-            ret[formatted_action_field[:-1] + '_apis'] = format_all_app_actions_api(api[formatted_action_field],
-                                                                                    app_name, formatted_action_field)
-        else:
-            ret[formatted_action_field[:-1] + '_apis'] = []
-    if 'devices' in api:
-        ret['device_apis'] = [format_device_api_full(device_api, device_name)
-                              for device_name, device_api in api['devices'].items()]
-    else:
-        ret['device_apis'] = []
+        ret[formatted_action_field[:-1] + '_apis'] = format_all_app_actions_api(getattr(api, formatted_action_field),
+                                                                                app_name, formatted_action_field)
+    ret['device_apis'] = [format_device_api_full(device_api, device_name)
+                          for device_name, device_api in api.devices.items()]
     return ret
 
 

--- a/walkoff/server/endpoints/devices.py
+++ b/walkoff/server/endpoints/devices.py
@@ -69,16 +69,15 @@ def delete_device(device_id):
 
 
 def add_configuration_keys_to_device_json(device_fields, device_fields_api):
-    device_fields_api = {field['name']: field for field in device_fields_api}
+    device_fields_api = {field.name: field for field in device_fields_api}
     for field in device_fields:
         add_configuration_keys_to_field(device_fields_api, field)
 
 
 def add_configuration_keys_to_field(device_fields_api, field):
     if field['name'] in device_fields_api:
-        field['type'] = device_fields_api[field['name']]['type']
-        if 'encrypted' in device_fields_api[field['name']]:
-            field['encrypted'] = device_fields_api[field['name']]['encrypted']
+        field['type'] = device_fields_api[field['name']].type
+        field['encrypted'] = device_fields_api[field['name']].encrypted
 
 
 def create_device():
@@ -105,7 +104,7 @@ def create_device():
         device_type = add_device_json['type']
         try:
             device_api = get_app_device_api(app, device_type)
-            device_fields_api = device_api['fields']
+            device_fields_api = device_api.fields
             validate_device_fields(device_fields_api, fields, device_type, app)
         except (UnknownApp, UnknownDevice, InvalidArgument) as e:
             return __crud_device_error_handler('create', e, app, device_type)
@@ -160,7 +159,7 @@ def _update_device(device, update_device_json, validate_required=True):
     device_type = update_device_json['type'] if 'type' in update_device_json else device.type
     try:
         device_api = get_app_device_api(app, device_type)
-        device_fields_api = device_api['fields']
+        device_fields_api = device_api.fields
         if fields is not None:
             validate_device_fields(device_fields_api, fields, device_type, app, validate_required=validate_required)
     except (UnknownApp, UnknownDevice, InvalidArgument) as e:


### PR DESCRIPTION
Partly Fixing #161 @JustinTervala /cc
The somewhat messy validation code depends kinda heavily on dictionaries.
Instead of rewriting the respective parts altogether, I used a few `.__dict__`.

Dedicated Api classes are used where possible, not sure if I missed some.
Some attributes are not declared in [`walkoff/api/objects/appapi.yaml`](https://github.com/iadgov/WALKOFF/blob/development/walkoff/api/objects/appapi.yaml) but used in code.
In affected classes, I have put them on a separate line and left a comment.