### PR TITLE
Core API errors

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,5 @@
 APscheduler >= 3.0.0
+pydantic == 0.32.2
 pyyaml >= 3.0
 passlib >= 1.7.0
 semver

--- a/api/server/db/mongo/__init__.py
+++ b/api/server/db/mongo/__init__.py
@@ -11,12 +11,12 @@ class MongoManager(object):
         self.async_client = motor.motor_asyncio.AsyncIOMotorClient(username=config.DB_USERNAME,
                                                                    password=config.get_from_file(config.MONGO_KEY_PATH),
                                                                    host=config.MONGO_HOST,
-                                                                   port=config.get_int("MONGO_PORT"))
+                                                                   port=config.get_int("MONGO_PORT",27016))
 
         self.reg_client = pymongo.MongoClient(username=config.DB_USERNAME,
                                               password=config.get_from_file(config.MONGO_KEY_PATH),
                                               host=config.MONGO_HOST,
-                                              port=config.get_int("MONGO_PORT"))
+                                              port=config.get_int("MONGO_PORT",27016))
 
         self.init_db()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pydantic == 0.32.2
 #aiodns
 aiodocker
 aiohttp

--- a/umpire/requirements.txt
+++ b/umpire/requirements.txt
@@ -1,3 +1,4 @@
+pydantic == 0.32.2
 docker
 docker-compose
 minio
@@ -10,5 +11,4 @@ six
 redis
 uvicorn
 tenacity
-pydantic
 email-validator


### PR DESCRIPTION
Resolved mongo connection fault introduced when sint() which requires a default that is type int by adding a default port for the mongo connection.

Added workaround for the breaking change that was made in pydantic by requiring version 0.32.2. Pydantic devs removed UrlStr in versions >=1.0 and replaced with AnyUrl class.