### PR TITLE
fix ./walkoff.sh fail

### DIFF
--- a/bootloader/Dockerfile
+++ b/bootloader/Dockerfile
@@ -28,9 +28,9 @@ RUN apt-get update \
 
 COPY --from=builder /install /usr/local
 #COPY ./.dockerignore /app/.dockerignore
-#COPY ./bootloader/ /app/bootloader
+COPY bootloader/bootloader.py /app/bootloader.py
 #COPY ./common /app/common
-#WORKDIR /app
+WORKDIR /app
 
 ENTRYPOINT ["python", "-m", "bootloader.bootloader"]
 


### PR DESCRIPTION
when you run "./walkoff.sh up --build" the image build of docker fails, need the step COPY for bootloader.py and the workdir in order to execute the python bootloader script.