### PR TITLE
Update Dockerfile - remove amd64 arch

### DIFF
--- a/bootloader/Dockerfile
+++ b/bootloader/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     apt-transport-https ca-certificates curl gnupg2 software-properties-common \
  && apt-key adv --fetch-keys https://download.docker.com/linux/debian/gpg \
- && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+ && add-apt-repository "deb https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
  && apt-get update \
  && apt-get install -y --no-install-recommends docker-ce-cli \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Build process fails on systems with a different architecture.