### PR TITLE
Fix: Update pydantic to fix broken fastapi imports

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,4 @@
 APscheduler >= 3.0.0
-pydantic == 0.32.2
 pyyaml >= 3.0
 passlib >= 1.7.0
 semver
@@ -23,4 +22,4 @@ websocket-client
 minio
 aiodocker == 0.14.0
 docker
-pydantic == 0.32.2
+pydantic

--- a/api/server/db/appapi.py
+++ b/api/server/db/appapi.py
@@ -3,7 +3,7 @@ from typing import List
 from uuid import UUID
 
 import semver
-from pydantic import BaseModel, validator, UrlStr, EmailStr
+from pydantic import BaseModel, validator, AnyUrl, EmailStr
 
 from api.server.db import IDBaseModel
 from api.server.db.action import ActionApiModel  # ActionApiSchema,
@@ -13,18 +13,18 @@ logger = logging.getLogger("API")
 
 class AppApiContactModel(BaseModel):
     name: str = ""
-    url: UrlStr = None
+    url: AnyUrl = None
     email: EmailStr = None
 
 
 class AppApiLicenseModel(BaseModel):
     name: str = ""
-    url: UrlStr = None
+    url: AnyUrl = None
 
 
 class AppExternalDocModel(BaseModel):
     description: str = ""
-    url: UrlStr = None
+    url: AnyUrl = None
 
 
 class AppApiModel(IDBaseModel):


### PR DESCRIPTION
Upstream fastapi requires updated pydantic, otherwise core_api container will crash on

```
ImportError: cannot import name 'FieldInfo' from 'pydantic.fields' (/usr/local/lib/python3.7/site-packages/pydantic/fields.cpython-37m-x86_64-linux-gnu.so)
```

Removed pydantic version lock in python requirements to use upstream version and implemented required changes. 