### PR TITLE
Fix: Lock fastapi to a compatible version

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -12,7 +12,7 @@ asteval
 cryptography
 tenacity
 uvicorn
-fastapi
+fastapi == 0.60.2
 email-validator
 motor
 aiofiles
@@ -23,4 +23,3 @@ websocket-client
 minio
 aiodocker == 0.14.0
 docker
-pydantic == 0.32.2


### PR DESCRIPTION
Lock fastapi version to the latest one supporting pydantic < 1.0.0

Fastapi since 0.61.0 requires pydantic > 1.0.0, see https://github.com/tiangolo/fastapi/releases/tag/0.61.0

New pydantic requires changes in Walkoff code and database operations.